### PR TITLE
beforeSubmit could disable Fields leading to submit loss

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -160,10 +160,10 @@ $.fn.ajaxSubmit = function(options) {
 	   // hack to fix Safari hang (thanks to Tim Molendijk for this)
 	   // see:  http://groups.google.com/group/jquery-dev/browse_thread/thread/36395b7ab510dd5d
 	   if (options.closeKeepAlive) {
-		   $.get(options.closeKeepAlive, fileUpload);
+		   $.get(options.closeKeepAlive, function() { fileUpload(a); });
 		}
 	   else {
-		   fileUpload();
+		   fileUpload(a);
 		}
    }
    else {
@@ -176,8 +176,13 @@ $.fn.ajaxSubmit = function(options) {
 
 
 	// private function for handling file uploads (hat tip to YAHOO!)
-	function fileUpload() {
+	function fileUpload(a) {
 		var form = $form[0];
+
+                // some elements might be disabled by beforeSubmit. enable.
+                for (key in a) {
+                  $(form[a[key].name]).attr('disabled', false);
+                }
 
 		if ($(':input[name=submit],:input[id=submit]', form).length) {
 			// if there is an input with a name or id of 'submit' then we won't be

--- a/jquery.form.js
+++ b/jquery.form.js
@@ -179,9 +179,11 @@ $.fn.ajaxSubmit = function(options) {
 	function fileUpload(a) {
 		var form = $form[0];
 
+                if (a) {
                 // some elements might be disabled by beforeSubmit. enable.
-                for (key in a) {
-                  $(form[a[key].name]).attr('disabled', false);
+                  for (key in a) {
+                    $(form[a[key].name]).attr('disabled', false);
+                  }
                 }
 
 		if ($(':input[name=submit],:input[id=submit]', form).length) {


### PR DESCRIPTION
Hi
We ran into issues with Drupal 6. It uses a beforeSubmit implementation that disables the origin form element of ahah action while ajax submission (jquery.form.js) happens.
However if the original form has a file upload present, jquery.form switches to fileUpload and rebuilds the form on ajax submit. In this case, exactly the origin element of the ajax action (disabled AFTER the beforeSubmit, right before form.submit) will be missing on the post.

We finally passed the original "a" to the fileUpload method and thus allow to reenable meanwhile disabled fields for the post to happen. It just took us many hours to understand the issue...

Please tell me if you suggest fixing the situation differentally.
