### PR TITLE
Ensure file input elements are enabled before using multipart

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -150,7 +150,7 @@ $.fn.ajaxSubmit = function(options) {
 	};
 
 	// are there files to upload?
-	var fileInputs = $('input:file', this).length > 0;
+	var fileInputs = $('input:file:enabled', this).length > 0;
 	var mp = 'multipart/form-data';
 	var multipart = ($form.attr('enctype') == mp || $form.attr('encoding') == mp);
 


### PR DESCRIPTION
Mike,

I was using your form plugin and noticed that it would post as 'multipart/form-data' when a file input element was present, even if it was disabled. It seems like it should only do multipart if there is an enabled file input element in the form. I'd appreciate it if you could take a look at the simple proposed change and let me know what you think.

Thanks,

Aaron
