### PR TITLE
IE issues with response

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -144,7 +144,7 @@ $.fn.ajaxSubmit = function(options) {
 	}
 
 	options.success = function(data, status, xhr) { // jQuery 1.4+ passes xhr as 3rd arg
-		var context = options.context || options;   // jQuery 1.4+ supports scope context 
+		var context = options.context || options;   // jQuery 1.4+ supports scope context
 		for (var i=0, max=callbacks.length; i < max; i++) {
 			callbacks[i].apply(context, [data, status, xhr || $form, $form]);
 		}
@@ -186,7 +186,7 @@ $.fn.ajaxSubmit = function(options) {
 			alert('Error: Form elements must not have name or id of "submit".');
 			return;
 		}
-		
+
 		var s = $.extend(true, {}, $.ajaxSettings, options);
 		s.context = s.context || s;
 		var id = 'jqFormIO' + (new Date().getTime()), fn = '_'+id;
@@ -228,7 +228,7 @@ $.fn.ajaxSubmit = function(options) {
 		}
 
 		if (s.beforeSend && s.beforeSend.call(s.context, xhr, s) === false) {
-			if (s.global) { 
+			if (s.global) {
 				$.active--;
 			}
 			return;
@@ -315,7 +315,7 @@ $.fn.ajaxSubmit = function(options) {
 		else {
 			setTimeout(doSubmit, 10); // this lets dom updates render
 		}
-	
+
 		var data, doc, domCheckCount = 50;
 
 		function cb() {
@@ -324,7 +324,7 @@ $.fn.ajaxSubmit = function(options) {
 			}
 
 			$io.removeData('form-plugin-onload');
-			
+
 			var ok = true;
 			try {
 				if (timedOut) {
@@ -332,7 +332,7 @@ $.fn.ajaxSubmit = function(options) {
 				}
 				// extract the server response from the iframe
 				doc = io.contentWindow ? io.contentWindow.document : io.contentDocument ? io.contentDocument : io.document;
-				
+
 				var isXml = s.dataType == 'xml' || doc.XMLDocument || $.isXMLDoc(doc);
 				log('isXml='+isXml);
 				if (!isXml && window.opera && (doc.body == null || doc.body.innerHTML == '')) {
@@ -350,7 +350,7 @@ $.fn.ajaxSubmit = function(options) {
 
 				//log('response detected');
 				cbInvoked = true;
-				xhr.responseText = doc.documentElement ? doc.documentElement.innerHTML : null; 
+				xhr.responseText = doc.documentElement ? doc.documentElement.innerHTML : null;
 				xhr.responseXML = doc.XMLDocument ? doc.XMLDocument : doc;
 				xhr.getResponseHeader = function(header){
 					var headers = {'content-type': s.dataType};
@@ -369,12 +369,13 @@ $.fn.ajaxSubmit = function(options) {
 						var pre = doc.getElementsByTagName('pre')[0];
 						var b = doc.getElementsByTagName('body')[0];
 						if (pre) {
-							xhr.responseText = pre.textContent;
+							// Get the text content of the node. jQuery 1.4+ has $.text
+							xhr.responseText = $.text ? $.text([pre]) : $(pre).text();
 						}
 						else if (b) {
 							xhr.responseText = b.innerHTML;
 						}
-					}			  
+					}
 				}
 				else if (s.dataType == 'xml' && !xhr.responseXML && xhr.responseText != null) {
 					xhr.responseXML = toXml(xhr.responseText);
@@ -387,7 +388,7 @@ $.fn.ajaxSubmit = function(options) {
 				xhr.error = e;
 				$.handleError(s, xhr, 'error', e);
 			}
-			
+
 			if (xhr.aborted) {
 				log('upload aborted');
 				ok = false;
@@ -462,7 +463,7 @@ $.fn.ajaxForm = function(options) {
 		log('terminating; zero elements found by selector' + ($.isReady ? '' : ' (DOM not ready)'));
 		return this;
 	}
-	
+
 	return this.ajaxFormUnbind().bind('submit.form-plugin', function(e) {
 		if (!e.isDefaultPrevented()) { // if event has been canceled, don't proceed
 			e.preventDefault();
@@ -526,7 +527,7 @@ $.fn.formToArray = function(semantic) {
 	if (!els) {
 		return a;
 	}
-	
+
 	var i,j,n,v,el,max,jmax;
 	for(i=0, max=els.length; i < max; i++) {
 		el = els[i];


### PR DESCRIPTION
In case of IE we may want to use the response text, but in some cases IE8 uses `<pre>` tags to wrap the content of the response JSON. But IE does not support `textContent` attribute, so the responseText will be left undefined.

In case of jQuery 1.4 there is a nice `jQuery.text` function, which grabs the text of all the child nodes, and previous versions have the `jQuery.fn.text` that does the same thing. Basically what `textContent` would do in standard compliant browsers. This fix solves that issue by using the appropriate function that is available.

Another solution would be to use
    xhr.responseText = pre.textContent || pre.innerText;
