### PR TITLE
Improved JSON dataType handling

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -363,12 +363,22 @@ $.fn.ajaxSubmit = function(options) {
 						else if (b) {
 							xhr.responseText = b.innerHTML;
 						}
-					}			  
+					}
 				}
 				else if (s.dataType == 'xml' && !xhr.responseXML && xhr.responseText != null) {
 					xhr.responseXML = toXml(xhr.responseText);
 				}
-				
+
+				if(s.dataType.toLowerCase() === 'json') {
+					var temp = xhr.responseText;
+					try {
+						xhr.responseText = $.parseJSON(xhr.responseText);
+					} catch(e) {
+						xhr.responseText = temp;
+						throw 'invalid JSON response';
+					}
+				}
+
 				data = httpData(xhr, s.dataType, s);
 			}
 			catch(e){

--- a/jquery.form.js
+++ b/jquery.form.js
@@ -346,7 +346,7 @@ $.fn.ajaxSubmit = function(options) {
 					return headers[header];
 				};
 
-				var scr = /(json|script)/.test(s.dataType);
+				var scr = /(json|script)/.test(s.dataType.toLowerCase());
 				if (scr || s.textarea) {
 					// see if user embedded response in textarea
 					var ta = doc.getElementsByTagName('textarea')[0];


### PR DESCRIPTION
I've made a few modifications to improve the response handling when the dataType JSON is set. This should reduce the gap between the behavior of jQuery.ajax and jQuery.ajaxForm when the latter is in iframe mode.
