### PR TITLE
support for xhr.status + correctly trigger ajaxError handlers

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -414,7 +414,7 @@ $.fn.ajaxSubmit = function(options) {
 				status = null;
 			}
 
-            if (typeof(xhr.status) === 'number') { // we've set xhr.status
+            if (xhr.status) { // we've set xhr.status
                 // jQuery.httpSuccess available in 1.4 but removed from 1.5
                 // IE sometimes returns 1223 when it should be 204 so treat it as success, see #1450
                 status = xhr.status >= 200 && xhr.status < 300 || xhr.status === 304 || xhr.status === 1223 ? 'success' : 'error';

--- a/jquery.form.js
+++ b/jquery.form.js
@@ -349,12 +349,18 @@ $.fn.ajaxSubmit = function(options) {
 				}
 
 				//log('response detected');
-				xhr.responseText = doc.body ? doc.body.innerHTML : doc.documentElement ? doc.documentElement.innerHTML : null; 
+                var docRoot = doc.body ? doc.body : doc.documentElement;
+				xhr.responseText = docRoot ? docRoot.innerHTML : null;
 				xhr.responseXML = doc.XMLDocument ? doc.XMLDocument : doc;
-				xhr.getResponseHeader = function(header){
+				xhr.getResponseHeader = function(header) {
 					var headers = {'content-type': s.dataType};
 					return headers[header];
 				};
+                // support for XHR 'status' & 'statusText' emulation :
+                if (docRoot) {
+                    xhr.status = Number( docRoot.getAttribute('status') ) || xhr.status;
+                    xhr.statusText = docRoot.getAttribute('statusText') || xhr.statusText;
+                }
 
 				var scr = /(json|script)/.test(s.dataType);
 				if (scr || s.textarea) {
@@ -362,6 +368,9 @@ $.fn.ajaxSubmit = function(options) {
 					var ta = doc.getElementsByTagName('textarea')[0];
 					if (ta) {
 						xhr.responseText = ta.value;
+                        // support for XHR 'status' & 'statusText' emulation :
+                        xhr.status = Number( ta.getAttribute('status') ) || xhr.status;
+                        xhr.statusText = ta.getAttribute('statusText') || xhr.statusText;
 					}
 					else if (scr) {
 						// account for browsers injecting pre around json response

--- a/jquery.form.js
+++ b/jquery.form.js
@@ -407,7 +407,9 @@ $.fn.ajaxSubmit = function(options) {
 			}
 
             if (typeof(xhr.status) === 'number') { // we've set xhr.status
-                status = $.httpSuccess( xhr ) ? 'success' : 'error';
+                // jQuery.httpSuccess available in 1.4 but removed from 1.5
+                // IE sometimes returns 1223 when it should be 204 so treat it as success, see #1450
+                status = xhr.status >= 200 && xhr.status < 300 || xhr.status === 304 || xhr.status === 1223 ? 'success' : 'error';
             }
 
 			// ordering of these callbacks/triggers is odd, but that's how $.ajax does it


### PR DESCRIPTION
hey malsup,

i did found it very limiting not having a `xhr.status` when doing an ajax file upload ...
since there's a `<textarea>` hack anyway i thought why not add another "hack" to receive the `status` (and `statusText` as well), here's what i did :
- i check for the `status` attribute on the document root (e.g. `<body>`)
- if the `<textarea>` hack is used i check for the `status` attribute on it as well
- it no status attribute everything stays as before : `xhr.status === 'n/a'`

now after adding this i discovered that even thought the `xhr.status` was being set correctly i still had issues with the `ajaxError` handler not being triggered correctly ... thus i changed the "status" handling logic a bit and now it's working flawlessly - so i thought it might be useful for others as well :)

K.
