### PR TITLE
Support the 'text' dataType

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -358,7 +358,7 @@ $.fn.ajaxSubmit = function(options) {
 					return headers[header];
 				};
 
-				var scr = /(json|script)/.test(s.dataType);
+				var scr = /(json|script|text)/.test(s.dataType);
 				if (scr || s.textarea) {
 					// see if user embedded response in textarea
 					var ta = doc.getElementsByTagName('textarea')[0];


### PR DESCRIPTION
Unless there's a reason I'm missing, it's a super simple change to support the text datatype since the response should be equal to json and script, just that it will never be jsonified or eval'd.
