### PR TITLE
add better support for forms with empty target attributes

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -56,11 +56,12 @@ $.fn.ajaxSubmit = function(options) {
 
 	var action = this.attr('action');
 	var url = (typeof action === 'string') ? $.trim(action) : '';
+	// check for default url first, then clean fragment identifier
+	url = url || window.location.href || '';
 	if (url) {
 		// clean url (don't include hash vaue)
 		url = (url.match(/^([^#]+)/)||[])[1];
 	}
-	url = url || window.location.href || '';
 
 	options = $.extend(true, {
 		url:  url,


### PR DESCRIPTION
If the form has an empty action attribute, set url to the default of
window.location.href before cleaning the fragment identifier to avoid
the following situation, with window.location.href = /foo/bar#baz:

``` html
<form action="" method="get">
  <input type="hidden" name="baaz" value="1">
</form>
```

Previously, on submit this would go to /foo/bar#baz?baaz=1, but now will go to
/foo/bar?baaz=1, as expected. In the prior case the server will ignore
everything after the #, so it will just be a GET to /foo/bar with no query
string.
