### PR TITLE
fix bug, only notice file inputs that actually have files

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -155,7 +155,7 @@ $.fn.ajaxSubmit = function(options) {
 	};
 
 	// are there files to upload?
-	var fileInputs = $('input:file', this).length > 0;
+	var fileInputs = $('input:file[value]', this).length > 0;
 	var mp = 'multipart/form-data';
 	var multipart = ($form.attr('enctype') == mp || $form.attr('encoding') == mp);
 


### PR DESCRIPTION
See issue: https://github.com/malsup/form/issues/113

Without this fix I get a never ending loop with `[jquery.form] state = uninitialized`
