### PR TITLE
Change 'attr' to 'removeAttr' for serialized inputs

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -192,11 +192,18 @@ $.fn.ajaxSubmit = function(options) {
         var useProp = !!$.fn.prop;
 
         if (a) {
-        	// ensure that every serialized input is still enabled
-          	for (i=0; i < a.length; i++) {
-                el = $(form[a[i].name]);
-                el[ useProp ? 'prop' : 'attr' ]('disabled', false);
-          	}
+            if ( useProp ) {
+            	// ensure that every serialized input is still enabled
+              	for (i=0; i < a.length; i++) {
+                    el = $(form[a[i].name]);
+                    el.prop('disabled', false);
+              	}
+            } else {
+              	for (i=0; i < a.length; i++) {
+                    el = $(form[a[i].name]);
+                    el.removeAttr('disabled');
+              	}
+            };
         }
 
 		if ($(':input[name=submit],:input[id=submit]', form).length) {


### PR DESCRIPTION
The documentation for removeAttr suggests you should remove the "disabled" attribute with "removeAttr('disabled')" instead of "attr('disabled', false)" (presumably for browsers that treat any existent value as true): http://api.jquery.com/removeAttr/

The documentation for 'prop' explicitly states that 'removeProp' is incorrect: http://api.jquery.com/removeProp/

This little bug could cause incorrect behaviour in some obscure browsers.

I found this while trying to compile jquery.form with closure.  Although the plugin uses undocumented interfaces a lot, this is the only proper violation of the interface.  I can provide more Closure-compatibility patches if you're interested, although I'll have to push some related patches to Closure's jQuery extern first.
