### PR TITLE
Use $.isArray instead of instanceof Array

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -91,7 +91,7 @@ $.fn.ajaxSubmit = function(options) {
 	if (options.data) {
 		options.extraData = options.data;
 		for (n in options.data) {
-			if(options.data[n] instanceof Array) {
+			if($.isArray(options.data[n])) {
 				for (var k in options.data[n]) {
 					a.push( { name: n, value: options.data[n][k] } );
 				}


### PR DESCRIPTION
instanceof may not work as expected across iframes.

$.isArray uses the native Array.isArray browser implementation that doens't have that side effect and is available in browsers as of ES5 ([JavaScript 1.8.5](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/isArray)) and falls back to an object type check ([source](https://github.com/jquery/jquery/blob/b22c9046529852c7ce567df13397849e11e2b9cc/src/core.js#L477)).
