### PR TITLE
Fix the XHR level 2 file uploads so as not to reorder the form data

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -48,6 +48,13 @@
 */
 
 /**
+ * Feature detection
+ */
+var feature = {};
+feature.fileapi = $("<input type='file'/>").get(0).files !== undefined;
+feature.formdata = window.FormData !== undefined;
+
+/**
  * ajaxSubmit() provides a mechanism for immediately submitting
  * an HTML form using AJAX.
  */
@@ -164,7 +171,7 @@ $.fn.ajaxSubmit = function(options) {
 	var mp = 'multipart/form-data';
 	var multipart = ($form.attr('enctype') == mp || $form.attr('encoding') == mp);
 
-	var fileAPI = !!(hasFileInputs && fileInputs.get(0).files && window.FormData);
+	var fileAPI = feature.fileapi && feature.formdata;
 	log("fileAPI :" + fileAPI);
 	var shouldUseFrame = (hasFileInputs || multipart) && !fileAPI;
 
@@ -199,18 +206,8 @@ $.fn.ajaxSubmit = function(options) {
 		var formdata = new FormData();
 
 		for (var i=0; i < a.length; i++) {
-			if (a[i].type == 'file')
-				continue;
 			formdata.append(a[i].name, a[i].value);
 		}
-
-		$form.find('input:file:enabled').each(function(){
-			var name = $(this).attr('name'), files = this.files;
-			if (name) {
-				for (var i=0; i < files.length; i++)
-					formdata.append(name, files[i]);
-			}
-		});
 
 		if (options.extraData) {
 			for (var k in options.extraData)
@@ -763,6 +760,12 @@ $.fn.formToArray = function(semantic) {
 		if (v && v.constructor == Array) {
 			for(j=0, jmax=v.length; j < jmax; j++) {
 				a.push({name: n, value: v[j]});
+			}
+		}
+		else if (feature.fileapi && el.type == 'file' && !el.disabled) {
+			var files = el.files;
+			for (j=0; j < files.length; j++) {
+				a.push({name: n, value: files[j], type: el.type});
 			}
 		}
 		else if (v !== null && typeof v != 'undefined') {


### PR DESCRIPTION
The HTML4 spec says the the parts in the "multipart/form-data" must appear in the same order as the corresponding form controls appear in the document.

The current code was moving all the file parts to the end of the post body.  This was confounding [peppercorn](http://docs.pylonsproject.org/projects/peppercorn/en/latest/) (which, in turn, is used by [deform](http://docs.pylonsproject.org/projects/deform/en/latest/).)  There’s more discussion of this at http://plope.com/peppercorn.
