### PR TITLE
Added required attribute value of input elements to formToArray return object

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -812,7 +812,7 @@ $.fn.formToArray = function(semantic, elements) {
         else if (v !== null && typeof v != 'undefined') {
             if (elements) 
                 elements.push(el);
-            a.push({name: n, value: v, type: el.type});
+            a.push({name: n, value: v, type: el.type, required: el.required});
         }
     }
 


### PR DESCRIPTION
Hi,

I added the HTML5 required attribute value to the formToArray function. I found this helpful when using the beforeSubmit callback for validation. The required property is defined once in the html and can then be handled with generic logic in the callback.

A simple example would be as follows...

```
beforeSubmit: function(arr, $form, options) {
    // The array of form data takes the following form:
    // [ { name: 'username', value: 'jresig', required: true }, { name: 'password', value: 'secret', required: true } ]
    // [ { name: 'title', value: '', required: false } ]

    $.each(arr, function(index, item) {
        if(item.required && !item.value.length) {
            console.log(item.name+" is required");
        }
    });
}
```

It currently only applies to elements of type input (see changes in commit) but this might need to be extended or limited depending on the W3C spec.

Nick
