### PR TITLE
Fix for IE8 returns 'get' for missing method attribute 

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -76,7 +76,12 @@ $.fn.ajaxSubmit = function(options) {
         options = { success: options };
     }
 
-    method = this.attr('method');
+	if ($.browser.msie && $.browser.version == 8 && !this[0].attributes.method.specified) {
+		method = undefined;
+	}
+	else {
+		method = this.attr('method');
+	}
     action = this.attr('action');
     url = (typeof action === 'string') ? $.trim(action) : '';
     url = url || window.location.href || '';


### PR DESCRIPTION
jQuery.attr method on a form in IE8, which have no method attribute,
will return 'get' instead of undefined. This makes the doSubmit default
to GET instead of POST as method for IE8.
