### PR TITLE
Ability to specify multiple fields with the same name on iframe submissions

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -426,9 +426,16 @@ $.fn.ajaxSubmit = function(options) {
                 if (s.extraData) {
                     for (var n in s.extraData) {
                         if (s.extraData.hasOwnProperty(n)) {
-                            extraInputs.push(
+                            // if using the $.param format that allows for multiple values with the same name
+                            if($.isPlainObject(s.extraData[n]) && s.extraData[n].hasOwnProperty('name') && s.extraData[n].hasOwnProperty('value')) {
+                                extraInputs.push(
+                                $('<input type="hidden" name="'+s.extraData[n].name+'">').attr('value',s.extraData[n].value)
+                                    .appendTo(form)[0]);
+                            } else {
+                                extraInputs.push(
                                 $('<input type="hidden" name="'+n+'">').attr('value',s.extraData[n])
                                     .appendTo(form)[0]);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Currently, you can use the $.param format for the options.data setting, e.g.

options.data = [{ name: 'test', :value: 'a value' }]

However, this format _doesn't_ work when submitting with iframes. This commit changes that by checking to see whether each element in the extraData array is an object and has the name and value keys, then builds the relevant hidden fields.

By supporting this syntax in iframe submissions, it allows for submitting multiple values for the same name.
