### PR TITLE
Allow custom form method on file upload

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -244,7 +244,7 @@ $.fn.ajaxSubmit = function(options) {
             contentType: false,
             processData: false,
             cache: false,
-            type: 'POST'
+            type: method || 'POST'
         });
         
         if (options.uploadProgress) {


### PR DESCRIPTION
When uploading a file using a form, it should use the user defined form
method otherwise use POST. It was previously set to always POST.
