### PR TITLE
Fixed usage of attr/prop for getting method+action

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -76,8 +76,8 @@ $.fn.ajaxSubmit = function(options) {
         options = { success: options };
     }
 
-    method = this.attr('method');
-    action = this.attr('action');
+    method = this.prop('method');
+    action = this.prop('action');
     url = (typeof action === 'string') ? $.trim(action) : '';
     url = url || window.location.href || '';
     if (url) {


### PR DESCRIPTION
This should fix issue #219 with newer jQuery versions. Using attr seems to fail at least for dynamically generated forms.

Note: There are many more usages of attr within malsup/form that are probably wrong. Don't have time for a fix currently, though.
