### PR TITLE
callbacks in form's context

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -120,7 +120,7 @@ $.fn.ajaxSubmit = function(options) {
     }
 
     // give pre-submit callback an opportunity to abort the submit
-    if (options.beforeSubmit && options.beforeSubmit(a, this, options) === false) {
+    if (options.beforeSubmit && options.beforeSubmit.call(this, a, options) === false) {
         log('ajaxSubmit: submit aborted via beforeSubmit callback');
         return this;
     }


### PR DESCRIPTION
Think it would be more useful to have `this` pointing to form object in callbacks.
For now i've just changed only beforeSubmit().
One problem - it's a little incompatible with previous versions, because parameters order has changed.
