### PR TITLE
Explicitly declare and check qx as undefined

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -113,7 +113,7 @@ $.fn.ajaxSubmit = function(options) {
     }
     
     var elements = [];
-    var qx, a = this.formToArray(options.semantic, elements);
+    var qx = undefined, a = this.formToArray(options.semantic, elements);
     if (options.data) {
         options.extraData = options.data;
         qx = $.param(options.data, traditional);
@@ -133,7 +133,7 @@ $.fn.ajaxSubmit = function(options) {
     }
 
     var q = $.param(a, traditional);
-    if (qx) {
+    if (qx !== undefined) {
         q = ( q ? (q + '&' + qx) : qx );
     }    
     if (options.type.toUpperCase() == 'GET') {


### PR DESCRIPTION
This change is mostly to avoid a warning in IDEs such as eclipse,
even though it's also formally "more right".
