### PR TITLE
File Inputs now cleared in clearFields function

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -1043,6 +1043,13 @@ $.fn.clearFields = $.fn.clearInputs = function(includeHidden) {
         else if (tag == 'select') {
             this.selectedIndex = -1;
         }
+		else if (t == "file") {
+			if ($.browser.msie) {
+				$(this).replaceWith($(this).clone());
+			} else {
+				$(this).val('');
+			}
+		}
         else if (includeHidden) {
             // includeHidden can be the value true, or it can be a selector string
             // indicating a special test; for example:


### PR DESCRIPTION
Existing clearFields function did not cover file inputs. Added code to clear in both IE and other browsers.
