### PR TITLE
Added support for functions in 'data' option for ajaxForm and ajaxSubmit.

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -115,14 +115,9 @@ $.fn.ajaxSubmit = function(options) {
     var elements = [];
     var qx, a = this.formToArray(options.semantic, elements);
     if (options.data) {
-    	var extraData;
-        if ($.isFunction(options.data)) {
-            extraData = options.data(a);
-        } else {
-            extraData = options.data;
-        }
-        options.extraData = extraData;
-        qx = $.param(extraData, traditional);
+        var optionsData = $.isFunction(options.data) ? options.data(a) : options.data;
+        options.extraData = optionsData;
+        qx = $.param(optionsData, traditional);
     }
 
     // give pre-submit callback an opportunity to abort the submit
@@ -224,22 +219,7 @@ $.fn.ajaxSubmit = function(options) {
     this.trigger('form-submit-notify', [this, options]);
     return this;
 
-    // utility fn for deep serialization
-    function deepSerialize(extraData){
-        var serialized = $.param(extraData).split('&');
-        var len = serialized.length;
-        var result = {};
-        var i, part;
-        for (i=0; i < len; i++) {
-            // #252; undo param space replacement
-            serialized[i] = serialized[i].replace(/\+/g,' ');
-            part = serialized[i].split('=');
-            result[decodeURIComponent(part[0])] = decodeURIComponent(part[1]);
-        }
-        return result;
-    }
-
-     // XMLHttpRequest Level 2 file uploads (big hat tip to francois2metz)
+    // XMLHttpRequest Level 2 file uploads (big hat tip to francois2metz)
     function fileUploadXhr(a) {
         var formdata = new FormData();
 
@@ -248,10 +228,9 @@ $.fn.ajaxSubmit = function(options) {
         }
 
         if (options.extraData) {
-            var serializedData = deepSerialize(options.extraData);
-            for (var p in serializedData)
-                if (serializedData.hasOwnProperty(p))
-                    formdata.append(p, serializedData[p]);
+            $.each(options.extraData, function (key, value) {
+                formdata.append(key, value);
+            });
         }
 
         options.data = null;

--- a/jquery.form.js
+++ b/jquery.form.js
@@ -115,8 +115,14 @@ $.fn.ajaxSubmit = function(options) {
     var elements = [];
     var qx, a = this.formToArray(options.semantic, elements);
     if (options.data) {
-        options.extraData = options.data;
-        qx = $.param(options.data, traditional);
+    	var extraData;
+        if ($.isFunction(options.data)) {
+            extraData = options.data(a);
+        } else {
+            extraData = options.data;
+        }
+        options.extraData = extraData;
+        qx = $.param(extraData, traditional);
     }
 
     // give pre-submit callback an opportunity to abort the submit

--- a/jquery.form.js
+++ b/jquery.form.js
@@ -219,6 +219,19 @@ $.fn.ajaxSubmit = function(options) {
     this.trigger('form-submit-notify', [this, options]);
     return this;
 
+    // utility fn for deep serialization
+    function deepSerialize(extraData){
+        var serialized = $.param(extraData).split('&');
+        var len = serialized.length;
+        var result = {};
+        var i, part;
+        for (i=0; i < len; i++) {
+            part = serialized[i].split('=');
+            result[decodeURIComponent(part[0])] = decodeURIComponent(part[1]);
+        }
+        return result;
+    }
+
     // XMLHttpRequest Level 2 file uploads (big hat tip to francois2metz)
     function fileUploadXhr(a) {
         var formdata = new FormData();
@@ -228,9 +241,10 @@ $.fn.ajaxSubmit = function(options) {
         }
 
         if (options.extraData) {
-            $.each(options.extraData, function (key, value) {
-                formdata.append(key, value);
-            });
+            var serializedData = deepSerialize(options.extraData);
+            for (var p in serializedData)
+                if (serializedData.hasOwnProperty(p))
+                    formdata.append(p, serializedData[p]);
         }
 
         options.data = null;


### PR DESCRIPTION
Currently the only way to attach dynamic data to a request is by work-arounds, like altering the form data in-place inside `beforeSubmit`. But it doesn't work in browsers that require an iFrame, as this hook is not invoked while re-collecting the data to create the form inside the iFrame.

A possible solution is to support a function to be specified as the `data` property for `ajaxForm` and `ajaxSubmit`; and that's what this pull request is about.

Cheers.
