### PR TITLE
fix error - Uncaught TypeError

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -465,11 +465,11 @@ $.fn.ajaxSubmit = function(options) {
                            // if using the $.param format that allows for multiple values with the same name
                            if($.isPlainObject(s.extraData[n]) && s.extraData[n].hasOwnProperty('name') && s.extraData[n].hasOwnProperty('value')) {
                                extraInputs.push(
-                               $('<input type="hidden" name="'+s.extraData[n].name+'">').attr('value',s.extraData[n].value)
+                               $('<input type="hidden" name="'+s.extraData[n].name+'">').val(s.extraData[n].value)
                                    .appendTo(form)[0]);
                            } else {
                                extraInputs.push(
-                               $('<input type="hidden" name="'+n+'">').attr('value',s.extraData[n])
+                               $('<input type="hidden" name="'+n+'">').val(s.extraData[n])
                                    .appendTo(form)[0]);
                            }
                         }


### PR DESCRIPTION
Fixes error in jquery.form.js, which cause type error 
when form has inputs with 'undefined' values. 
As $('<input>').attr('value', undefined) === $('<input>').attr('value') 
the return of this construction is not jQuery collection 
but actual value, and thus doesn't have appendTo member-method.
