### PR TITLE
Replace deprecated $.browser.msie call.

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -1046,7 +1046,7 @@ $.fn.clearFields = $.fn.clearInputs = function(includeHidden) {
             this.selectedIndex = -1;
         }
 		else if (t == "file") {
-			if ($.browser.msie) {
+			if (/MSIE/.test(navigator.userAgent)) {
 				$(this).replaceWith($(this).clone());
 			} else {
 				$(this).val('');


### PR DESCRIPTION
Replace deprecated $.browser.msie call, removed in jQuery 1.9, with
test for /MSIE/ in navigator.userAgent.
