### PR TITLE
Enable elements with id/name "submit"

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -292,14 +292,6 @@ $.fn.ajaxSubmit = function(options) {
         var useProp = !!$.fn.prop;
         var deferred = $.Deferred();
 
-        if ($('[name=submit],[id=submit]', form).length) {
-            // if there is an input with a name or id of 'submit' then we won't be
-            // able to invoke the submit fn on the form (at least not x-browser)
-            alert('Error: Form elements must not have name or id of "submit".');
-            deferred.reject();
-            return deferred;
-        }
-        
         if (a) {
             // ensure that every serialized input is still enabled
             for (i=0; i < elements.length; i++) {
@@ -485,7 +477,9 @@ $.fn.ajaxSubmit = function(options) {
                         io.addEventListener('load', cb, false);
                 }
                 setTimeout(checkState,15);
-                form.submit();
+                // just in case form has element with name/id of 'submit'
+                var submitFn = document.createElement('form').submit;
+                submitFn.apply(form);
             }
             finally {
                 // reset attrs and remove "extra" input elements

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "form",
+  "name": "patterns-jquery-form",
   "title": "Form",
   "description": "A simple way to AJAX-ify any form on your page; with file upload and progress support.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -28,6 +28,15 @@
   "download": "http://malsup.github.com/jquery.form.js",
   "dependencies": {
     "jquery": ">=1.5"
+  },
+  "jam": {
+    "main": "jquery.form.js",
+    "dependencies": {
+      "jquery": ">=1.4.2"
+    },
+    "shim": {
+      "deps": ["jquery"]
+    }
   }
 }
 


### PR DESCRIPTION
This change works for us. There might be corner-cases we do not cover. Please let me know if I should change something. I'd like to get this or something similar into jquery.form and dissolve our fork.
