### PR TITLE
Make clear forms option configurable

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -763,6 +763,10 @@ function doAjaxSubmit(e) {
     }
 }
 
+// disable this when form submissions are to slow (and are cleared before actual
+//  submission) and the form gets replaced anyway.
+$.fn.ajaxSubmit.clearFormVariables = true; 
+
 function captureSubmittingElement(e) {
     /*jshint validthis:true */
     var target = e.target;
@@ -791,7 +795,9 @@ function captureSubmittingElement(e) {
         }
     }
     // clear form vars
-    setTimeout(function() { form.clk = form.clk_x = form.clk_y = null; }, 100);
+    if($.fn.ajaxSubmit.clearFormVariables) {
+        setTimeout(function() { form.clk = form.clk_x = form.clk_y = null; }, 100);
+    }
 }
 
 
@@ -1040,7 +1046,7 @@ $.fn.clearFields = $.fn.clearInputs = function(includeHidden) {
         else if (tag == 'select') {
             this.selectedIndex = -1;
         }
-		else if (t == "file") {
+    	else if (t == "file") {
 			if (/MSIE/.test(navigator.userAgent)) {
 				$(this).replaceWith($(this).clone());
 			} else {


### PR DESCRIPTION
We had an issue with unexpected behaviours when submitting forms with buttons with a 'name'. In some cases this name was not submitted with the form. 

Setting 'debug' to true would make this problem go away, this made it look like a timing issue.

Disabling the form clear variables setTimeout fixed the issue for us and the name is now submitted consistently. We do not re-use the form anyway so for us this flag solves the problem. 

Maybe a good configuration option to have by default, hereby the pull request containing this feature.
