### PR TITLE
Add Composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,28 @@
+{
+  "name": "malsup/form",
+  "description": "A simple way to AJAX-ify any form on your page; with file upload and progress support.",
+  "type": "component",
+  "homepage": "http://jquery.malsup.com/form/",
+  "keywords": [
+    "form",
+    "upload",
+    "ajax"
+  ],
+  "support": {
+    "issues": "https://github.com/malsup/form/issues",
+    "wiki": "http://jquery.malsup.com/form/"
+  },
+  "authors": [
+    {
+      "name": "M. Alsup",
+      "homepage": "http://jquery.malsup.com"
+    }
+  ],
+  "license": [
+    "MIT",
+    "GPL-2.0"
+  ],
+  "require": {
+    "components/jquery": ">=1.5"
+  }
+}


### PR DESCRIPTION
[Composer](http://getcomposer.org) is a package manager for PHP. This allows jQuery Form to be downloaded and installed with Composer.

With this PR, you can specify "maljsup/form" in your own composer.json to have it download jQuery Form.
