### PR TITLE
Add Composer component details

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,17 @@
   ],
   "require": {
     "components/jquery": ">=1.5"
+  },
+  "extra": {
+    "component": {
+      "scripts": [
+        "jquery.form.js"
+      ],
+      "shim": {
+        "deps": [
+          "jquery"
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
When installing jQuery Form via Composer, this allows jQuery Form to be used via the compiled Require.js configuration.

Thanks a lot for merging these changes forward!
