### PR TITLE
Fallback on Zepto if jQuery is not available.

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -1187,4 +1187,4 @@ function log() {
     }
 }
 
-})(jQuery);
+})(window.jQuery||window.Zepto);


### PR DESCRIPTION
Fallback on Zepto if jQuery is not available.

This is useful since popular frameworks like Foundation by default include Zepto rather than jQuery for browsers that support it.

Note that I have not tested form.js under Zepto. However, I believe this is still the right first step.

Zepto aims to be mostly compatible with jQuery, so there's a good chance that it will just work out of the box.

If not, we will discover specific Zepto compatibility issues, which may or may not be fixed, but either way the errors will be more helpful than "jQuery doesn't exist".
