### PR TITLE
fix typo in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "author": "M. Alsup",
   "dependencies": {
     "jquery": ">=1.5"
-  }
+  },
   "ignore": [
     "README.md",
     "composer.json",


### PR DESCRIPTION
a comma was missing before `"ignore"` key.
