### PR TITLE
fix referencing undefined in ajaxSubmit()

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -90,8 +90,8 @@ $.fn.ajaxSubmit = function(options) {
         options = { success: options };
     }
 
-    method = options.type || this.attr2('method');
-    action = options.url  || this.attr2('action');
+    method = (options && options.type) || this.attr2('method');
+    action = (options && options.url)  || this.attr2('action');
 
     url = (typeof action === 'string') ? $.trim(action) : '';
     url = url || window.location.href || '';


### PR DESCRIPTION
If argument of ajaxSubmit is not set, line 93/94 - options.type and options.url make an exception.
So I added check it before refer an undefined object.
