### PR TITLE
Fix iFrame abort()

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -767,7 +767,7 @@ $.fn.ajaxSubmit = function(options) {
             return data;
         };
 
-        return deferred;
+        return xhr;
     }
 };
 


### PR DESCRIPTION
When submitting with iFrame, return xhr instead of deferred to allow using abort()
