### PR TITLE
Treat header name as case-insensitive when calling getResponseHeader() on mock XHR object

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -537,7 +537,7 @@ $.fn.ajaxSubmit = function(options) {
                     s.dataType = 'xml';
                 xhr.getResponseHeader = function(header){
                     var headers = {'content-type': s.dataType};
-                    return headers[header];
+                    return headers[header.toLowerCase()];
                 };
                 // support for XHR 'status' & 'statusText' emulation :
                 if (docRoot) {


### PR DESCRIPTION
This is the tiniest of trivial requests, so please bear with me.

jQuery AJAX [lowercases header names](https://github.com/jquery/jquery/blob/master/src/ajax.js#L340-L351) passed as arguments to getResponseHeader(), so I thought it would be nice if the form plugin did so for feature parity (this discrepancy actually bit me, hence the PR).
