### PR TITLE
Fix warning by Google Closure compiler

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -1,7 +1,7 @@
 /*!
  * jQuery Form Plugin
  * version: 3.40.0-2013.08.13
- * @requires jQuery v1.5 or later
+ * requires jQuery v1.5 or later
  * Copyright (c) 2013 M. Alsup
  * Examples and documentation at: http://malsup.com/jquery/form/
  * Project repository: https://github.com/malsup/form


### PR DESCRIPTION
That @ will generate the following warning in Google Closure Compiler:

<pre>
Aug 23, 2013 3:08:27 PM com.google.javascript.jscomp.LoggerErrorManager println
WARNING: /home/rodrigo/.matterhorn/grails-assets/development/static/js/jquery/form/jquery.form.js:1: WARNING - Parse error. Non-JSDoc comment has annotations. Did you mean to start it with '/**'?
/*!
^

Aug 23, 2013 3:08:27 PM com.google.javascript.jscomp.LoggerErrorManager printSummary
WARNING: 0 error(s), 1 warning(s)
</pre>
