### PR TITLE
Fix File Upload Issue With No Value

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -209,7 +209,7 @@ $.fn.ajaxSubmit = function(options) {
 
     // [value] (issue #113), also see comment:
     // https://github.com/malsup/form/commit/588306aedba1de01388032d5f42a60159eea9228#commitcomment-2180219
-    var fileInputs = $('input[type=file]:enabled:not([value=""])', this);
+    var fileInputs = $('input[type=file]:enabled', this).filter(function() { return $(this).val() != ''; });
 
     var hasFileInputs = fileInputs.length > 0;
     var mp = 'multipart/form-data';


### PR DESCRIPTION
With the jQuery versions higher than 1.8.3 (1.10.2 in our site), I was encountering an issue where an Ajax file upload was not being sent as multi-part. I found this issue was due to the value attribute selector not getting the correct value for the file input element, so not([value==""]) was always false. I changed it to use the filter function instead and used val() to check the actual value. This works better at checking the value.
