### PR TITLE
Fix for delegation.

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -832,7 +832,7 @@ function doAjaxSubmit(e) {
     var options = e.data;
     if (!e.isDefaultPrevented()) { // if event has been canceled, don't proceed
         e.preventDefault();
-        $(this).ajaxSubmit(options);
+        $(e.target).ajaxSubmit(options);
     }
 }
 


### PR DESCRIPTION
Delegation doesn't work properly. It fails to copy the "method" and "action" attributes from the form, since it looks for them on... the document.
