### PR TITLE
Support inputs using HTML5 form attribute

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -907,7 +907,13 @@ $.fn.formToArray = function(semantic, elements) {
     }
 
     var form = this[0];
-    var els = semantic ? form.getElementsByTagName('*') : form.elements;
+    var els;
+    var formId = form.getAttribute('id');
+    if (formId !== null && $('[form="' + formId + '"]').length) {
+        els = $('[form="' + formId + '"], #' + formId + ' *').toArray();
+    } else {
+        els = semantic ? form.getElementsByTagName('*') : form.elements;
+    }
     if (!els) {
         return a;
     }


### PR DESCRIPTION
Provide support for input elements outside the form element they reference via the HTML5 form attribute.

See #385
