### PR TITLE
Add support for file download using cookie

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -657,7 +657,7 @@ $.fn.ajaxSubmit = function(options) {
 
             if (!doc || doc.location.href == s.iframeSrc) {
                 // response not received yet
-                if (!timedOut) {
+                if (!timedOut && e !== FILE_DOWNLOAD_SUCCESS) {
                     return;
                 }
             }


### PR DESCRIPTION
This commits enable support for detecting a successful file download using cookie.
This feature is useful when exchanging files, upload a file a get a new one as result.
Since the plugin jQuery.fileDownload doesn't support well the file upload part, I choose to add this bit to this library.

Added the new option 'fileDownload:bool'.
When enabled a polling check is started that waits for the cookie 'jQueryFormFileDownload=true' to be set.
