### PR TITLE
options.success can be an array of functions

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -194,7 +194,7 @@ $.fn.ajaxSubmit = function(options) {
         });
     }
     else if (options.success) {
-        callbacks.push(options.success);
+        $.isArray(options.success) ? callbacks.push.apply(callbacks, options.success) : callbacks.push(options.success);
     }
 
     options.success = function(data, status, xhr) { // jQuery 1.4+ passes xhr as 3rd arg


### PR DESCRIPTION
The jQuery doc of $.ajax() states: "As of jQuery 1.5, the success setting can accept an array of functions. Each function will be called in turn."

This improvement takes this in account and improves the compatibility with the existing options of $.ajax()
