### PR TITLE
Fix selectors with dotted-path form id's with jQuery 1.9

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -955,7 +955,7 @@ $.fn.formToArray = function(semantic, elements) {
     }
 
     // #386; account for inputs outside the form which use the 'form' attribute
-    // #XXX: Fix selectors with dotted-path form id's with jQuery 1.9.
+    // #419: Fix selectors with dotted-path form id's with jQuery 1.9.
     //     > $(':input[form="a.dotted.path"]').get();
     //     []
     //     > $(':input[form=a.dotted.path]').get();

--- a/jquery.form.js
+++ b/jquery.form.js
@@ -955,8 +955,13 @@ $.fn.formToArray = function(semantic, elements) {
     }
 
     // #386; account for inputs outside the form which use the 'form' attribute
+    // #XXX: Fix selectors with dotted-path form id's with jQuery 1.9.
+    //     > $(':input[form="a.dotted.path"]').get();
+    //     []
+    //     > $(':input[form=a.dotted.path]').get();
+    //     Error: Syntax error, unrecognized expression: :input[form=a.dotted.path]
     if ( formId ) {
-        els2 = $(':input[form=' + formId + ']').get();
+        els2 = $(':input[form="' + formId + '"]').get();
         if ( els2.length ) {
             els = (els || []).concat(els2);
         }


### PR DESCRIPTION
The following error happened with jQuery 1.9:

> $(':input[form=a.dotted.path]').get();
> Error: Syntax error, unrecognized expression: :input[form=a.dotted.path] 

That works:

> $(':input[form="a.dotted.path"]').get();
> []
