### PR TITLE
In fileUploadXhr: The beforeSend wrapper should return the wrapped return value

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -340,8 +340,9 @@ $.fn.ajaxSubmit = function(options) {
                 o.data = formdata;
             }
             if(beforeSend) {
-                beforeSend.call(this, xhr, o);
+                return beforeSend.call(this, xhr, o);
             }
+            return true;
         };
         return $.ajax(s);
     }


### PR DESCRIPTION
In fileUploadXhr: The beforeSend wrapper should return the wrapped return value, or true if nothing is wrapped.
