### PR TITLE
Update CDN path to reflect new tag version format

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The Form Plugin supports use of [XMLHttpRequest Level 2]("http://www.w3.org/TR/X
 ---
 
 ##CDN Support
-`<script src="//oss.maxcdn.com/jquery.form/3.50.0/jquery.form.min.js"></script>`
+`<script src="//oss.maxcdn.com/jquery.form/3.50/jquery.form.min.js"></script>`
 
 ##Copyright and License
 Copyright 2006-2013 (c) M. Alsup


### PR DESCRIPTION
the CDN version directory now seems to be major.minor (without patch level .0)
