### PR TITLE
Ignore JS errors in iframe scope

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -579,9 +579,11 @@ $.fn.ajaxSubmit = function(options) {
                 }
                 if (io.attachEvent) {
                     io.attachEvent('onload', cb);
+                    io.attachEvent('onerror', onIframeJSError);
                 }
                 else {
                     io.addEventListener('load', cb, false);
+                    io.addEventListener('error', onIframeJSError, false);
                 }
                 setTimeout(checkState,15);
 
@@ -614,6 +616,10 @@ $.fn.ajaxSubmit = function(options) {
         }
 
         var data, doc, domCheckCount = 50, callbackProcessed;
+
+        function onIframeJSError(e) {
+            return true;
+        }
 
         function cb(e) {
             if (xhr.aborted || callbackProcessed) {


### PR DESCRIPTION
Since this iframe is not exposed to outside, it is better to silent fail any JavaScript error internally. Otherwise it will surface to top.

Or there could be a option to set if ignore iframe scope error.
