### PR TITLE
Allow formToArray and ajaxSubmit to work on non-form tags

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -947,7 +947,7 @@ $.fn.formToArray = function(semantic, elements) {
 
     var form = this[0];
     var formId = this.attr('id');
-    var els = semantic ? form.getElementsByTagName('*') : form.elements;
+    var els = (semantic || form.elements === undefined) ? form.getElementsByTagName('*') : form.elements;
     var els2;
 
     if (els && !/MSIE [678]/.test(navigator.userAgent)) { // #390


### PR DESCRIPTION
This allows for `formToArray()` and therefore `ajaxSubmit()` to work on arbitrary elements and not just `<form>` tags without enabling semantic mode which has other side effects.

I checked for other consequences but haven't found any. Tested in IE/Chrome/Firefox.
