### PR TITLE
Outside fields bug fix

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -955,7 +955,8 @@ $.fn.formToArray = function(semantic, elements) {
     }
 
     // #386; account for inputs outside the form which use the 'form' attribute
-    if ( formId ) {
+    // FinesseRus: in non-IE browsers outside fields are already included in form.elements.
+    if (formId && (semantic || /MSIE/.test(navigator.userAgent))) {
         els2 = $(':input[form="' + formId + '"]').get(); // hat tip @thet
         if ( els2.length ) {
             els = (els || []).concat(els2);

--- a/jquery.form.js
+++ b/jquery.form.js
@@ -956,7 +956,7 @@ $.fn.formToArray = function(semantic, elements) {
 
     // #386; account for inputs outside the form which use the 'form' attribute
     // FinesseRus: in non-IE browsers outside fields are already included in form.elements.
-    if (formId && (semantic || /MSIE/.test(navigator.userAgent))) {
+    if (formId && (semantic || /(Edge|Trident)\//.test(navigator.userAgent))) {
         els2 = $(':input[form="' + formId + '"]').get(); // hat tip @thet
         if ( els2.length ) {
             els = (els || []).concat(els2);


### PR DESCRIPTION
In non-IE browsers outside fields are already included in `elements` attribute of form, so there is no need to add outside fields again.
