### PR TITLE
node.js support

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -16,6 +16,8 @@
     if (typeof define === 'function' && define.amd) {
         // using AMD; register as anon module
         define(['jquery'], factory);
+    } if (typeof module !== 'undefined' {
+		factory(require('jquery'));
     } else {
         // no AMD; invoke directly
         factory( (typeof(jQuery) != 'undefined') ? jQuery : window.Zepto );


### PR DESCRIPTION
for node.js environments (typically used with browserify), there is no
’jQuery’ variable predefined in the `window` since there are no
windows.  in that case we require jQuery and everything just works.
alternatively, the module needs to be shimmed.
