### PR TITLE
added option to use a given runtime url extension (options.pext)

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -119,7 +119,7 @@ $.fn.ajaxSubmit = function(options) {
     }
 
     options = $.extend(true, {
-        url:  url,
+        url:  url+(options.pext?'.'+options.pext:'.json'),
         success: $.ajaxSettings.success,
         type: method || $.ajaxSettings.type,
         iframeSrc: /^https/i.test(window.location.href || '') ? 'javascript:false' : 'about:blank'


### PR DESCRIPTION
Don't know if this can be helpful to anyone, but it was much needed when working with cakephp requests (URL-based, es. /users/index vs /users/index.json).

You can now use `ajaxSubmit` with a new `pext` parameter automatically added to the used url.

ie. `#TextForm` has `action="/users/index"`.
`$('form#TestForm').ajaxSubmit({'pext': 'xml', 'dataType': 'text', success: function(data) {});`

passing `'pext': 'xml'` the form will be submitted to `"/users/index.xml"`
