### PR TITLE
Change the way of submited form is retreived

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -903,7 +903,7 @@ function captureSubmittingElement(e) {
         }
         target = t[0];
     }
-    var form = this;
+    var form = target.form;
     form.clk = target;
     if (target.type == 'image') {
         if (e.offsetX !== undefined) {


### PR DESCRIPTION
In certain conditions 'this' is not the form but the window, this cause the submit button to not be found when checked if button is clicked
This patch retrieve form from the input element