### PR TITLE
restore value capturing for forms without submit button

### DIFF
--- a/jquery.form.js
+++ b/jquery.form.js
@@ -887,7 +887,7 @@ function doAjaxSubmit(e) {
     var options = e.data;
     if (!e.isDefaultPrevented()) { // if event has been canceled, don't proceed
         e.preventDefault();
-        $(e.target).ajaxSubmit(options); // #365
+        $(e.target).closest('form').ajaxSubmit(options); // #365
     }
 }
 


### PR DESCRIPTION
In our code base we have a few tiny forms like this, that are just a
checkbox that trigger an ajax post:

<form action="/" method="post" id="domain_haupt_form_asd_de">
    <input type="hidden" name="domain" value="asd.de">
    <input type="checkbox" onchange="$(this).submit()">
</form>

Before the fix for #365 was included this worked perfectly fine, but after
its inclusion the value for domain stopped being sent along, since e.target
points at the checkbox input and ajaxSubmit sends that input to
formToArray, which has no clue as to what to do with it and fails to
extract the form values.