### PR TITLE
When submitting encode all line breaks in the values as CRLF pairs

### DIFF
--- a/src/jquery.form.js
+++ b/src/jquery.form.js
@@ -165,7 +165,7 @@ $.fn.ajaxSubmit = function(options, data, dataType, onSuccess) {
 	}
 
 	var elements = [];
-	var qx, a = this.formToArray(options.semantic, elements, options.filtering);
+	var qx, a = this.serializeArray(this.formToArray(options.semantic, elements, options.filtering));
 	if (options.data) {
 		var optionsData = $.isFunction(options.data) ? options.data(a) : options.data;
 		options.extraData = optionsData;


### PR DESCRIPTION
We've just found out in Drupal (@see https://www.drupal.org/node/2856801) that ajax submission through ajaxSubmit don't hold up to the specification and is not encoding new lines as CRLF pairs, but only as LF.
This leads to a difference between browser and ajax submission and the values are different, which might have all possible consequences in the later processing. Browsers encode new lines as CRLF pairs, so should ajax submission as well.

jQuery has a support for this and introduced the functions serialize and serializeArray, which are processing the form values and ensuring new lines are encoded as CRLF pairs. This change hasn't been yet adopted in jquery-form, but it should.

Links about this, that I've found:
https://bugs.jquery.com/ticket/9007
https://bugs.jquery.com/ticket/6876

And the according commit:
https://github.com/jquery/jquery/commit/eed3803c98bf5c074e40aad12f2e91435bf81154

I hope it could be backported as well? 