### PR TITLE
Update default iframeSrc to be 'about:blank' for browsers other than IE

### DIFF
--- a/src/jquery.form.js
+++ b/src/jquery.form.js
@@ -156,7 +156,7 @@
 		}
 		// IE requires javascript:false in https, but this breaks chrome >83 and goes against spec.
 		// Instead of using javascript:false always, let's only apply it for IE.
-		isMsie = /(MSIE|trident)/.test(navigator.userAgent || '');
+		isMsie = /(MSIE|Trident)/.test(navigator.userAgent || '');
 		iframeSrc = (isMsie && /^https/i.test(window.location.href || '')) ? 'javascript:false' : 'about:blank'; // eslint-disable-line no-script-url
 
 		options = $.extend(true, {

--- a/src/jquery.form.js
+++ b/src/jquery.form.js
@@ -159,7 +159,7 @@
 			url       : url,
 			success   : $.ajaxSettings.success,
 			type      : method || $.ajaxSettings.type,
-			iframeSrc : /^https/i.test(window.location.href || '') ? 'javascript:false' : 'about:blank'		// eslint-disable-line no-script-url
+			iframeSrc : 'about:blank'
 		}, options);
 
 		// hook for manipulating the form data before it is extracted;

--- a/src/jquery.form.js
+++ b/src/jquery.form.js
@@ -125,7 +125,7 @@
 		}
 
 		/* eslint consistent-this: ["error", "$form"] */
-		var method, action, url, $form = this;
+		var method, action, url, isMsie, iframeSrc, $form = this;
 
 		if (typeof options === 'function') {
 			options = {success: options};
@@ -154,12 +154,16 @@
 			// clean url (don't include hash vaue)
 			url = (url.match(/^([^#]+)/) || [])[1];
 		}
+		// IE requires javascript:false in https, but this breaks chrome >83 and goes against spec.
+		// Instead of using javascript:false always, let's only apply it for IE.
+		isMsie = /(MSIE|trident)/.test(navigator.userAgent || '');
+		iframeSrc = (isMsie && /^https/i.test(window.location.href || '')) ? 'javascript:false' : 'about:blank'; // eslint-disable-line no-script-url
 
 		options = $.extend(true, {
 			url       : url,
 			success   : $.ajaxSettings.success,
 			type      : method || $.ajaxSettings.type,
-			iframeSrc : 'about:blank'
+			iframeSrc : iframeSrc
 		}, options);
 
 		// hook for manipulating the form data before it is extracted;


### PR DESCRIPTION
Resolves #571 

As stated in #571 [chrome is expecting "about:blank"](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element%5D%5B4.8.5_The_iframe_element%5D)

yet we're passing `javascript:false` if the page is HTTPS.

This was originally added with this default value in ce4324159ecd44cab4779bef6f6d484aef958c5c without any real explanation for why `javascript:false` was used. 

Given that "about:blank" is required in the spec and it fixes the current issue with Chrome, let's use it as the default even for HTTPS.

Edit:
`javacript:false` is required by IE browsers, this PR applies the javascript:false default only when the browser is detected to be IE.