### PR TITLE
Replace $.trim due to jQuery deprecation

### DIFF
--- a/src/jquery.form.js
+++ b/src/jquery.form.js
@@ -88,6 +88,10 @@
 		at the appropriate time.
 	*/
 
+	function trim (string) {
+		return string.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
+	}
+
 	var rCRLF = /\r?\n/g;
 
 	/**
@@ -159,7 +163,7 @@
 		method = options.method || options.type || this.attr2('method');
 		action = options.url || this.attr2('action');
 
-		url = (typeof action === 'string') ? $.trim(action) : '';
+		url = (typeof action === 'string') ? trim(action) : '';
 		url = url || window.location.href || '';
 		if (url) {
 			// clean url (don't include hash vaue)


### PR DESCRIPTION
Polyfill code from MDN added as separate function to avoid no-native-extend ESLint error.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim#Polyfill