### PR TITLE
Improve jQuery 3 compatibility

### DIFF
--- a/src/jquery.form.js
+++ b/src/jquery.form.js
@@ -479,7 +479,7 @@
 				}
 
 			} else {
-				$io = $('<iframe name="' + id + '" src="' + s.iframeSrc + '" />', ownerDocument);
+				$io = $('<iframe name="' + id + '" src="' + s.iframeSrc + '" ></iframe>', ownerDocument);
 				$io.css({position: 'absolute', top: '-1000px', left: '-1000px'});
 			}
 			io = $io[0];

--- a/src/jquery.form.js
+++ b/src/jquery.form.js
@@ -159,7 +159,7 @@
 		method = options.method || options.type || this.attr2('method');
 		action = options.url || this.attr2('action');
 
-		url = (typeof action === 'string') ? $.trim(action) : '';
+		url = (typeof action === 'string') ? action.trim() : '';
 		url = url || window.location.href || '';
 		if (url) {
 			// clean url (don't include hash vaue)
@@ -206,7 +206,7 @@
 		var qx, a = this.formToArray(options.semantic, elements, options.filtering);
 
 		if (options.data) {
-			var optionsData = $.isFunction(options.data) ? options.data(a) : options.data;
+			var optionsData = typeof options.data === 'function' ? options.data(a) : options.data;
 
 			options.extraData = optionsData;
 			qx = $.param(optionsData, traditional);
@@ -268,7 +268,7 @@
 			});
 
 		} else if (options.success) {
-			if ($.isArray(options.success)) {
+			if (Array.isArray(options.success)) {
 				$.merge(callbacks, options.success);
 			} else {
 				callbacks.push(options.success);
@@ -985,7 +985,7 @@
 		}
 
 		options = options || {};
-		options.delegation = options.delegation && $.isFunction($.fn.on);
+		options.delegation = options.delegation && typeof $.fn.on === 'function';
 
 		// in jQuery 1.3+ we can fix mistakes with the ready state
 		if (!options.delegation && this.length === 0) {
@@ -1123,7 +1123,7 @@
 			return a;
 		}
 
-		if ($.isFunction(filtering)) {
+		if (typeof filtering === 'function') {
 			els = $.map(els, filtering);
 		}
 


### PR DESCRIPTION
Hi there 👋 

This PR mainly changes some jQuery deprecated methods to their respective native methods. It also fixes an element selector.

These changes will help with the purpose of being compatible with jQuery 3 as it has been tracked on #544.

By the way, I also did run the tests and all of them had the green check 😄